### PR TITLE
Changing outline to border

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,17 +1,17 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap");
+
 * {
 	box-sizing: border-box;
 }
 
 html {
-	font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+	font-family: "Roboto", sans-serif;
 	font-weight: lighter;
 }
 
 body {
-	/* background-image: linear-gradient(#132f44, rgb(255, 255, 255)); */
 	background-color: #e0e0e0;
 	min-width: 900px;
-	/* padding-bottom: 50px; */
 }
 
 main {
@@ -40,7 +40,7 @@ input {
 	margin: 40px auto 0;
 	display: flex;
 	justify-content: center;
-	border: none;
+	border: 2px solid rgba(0, 0, 0, 0);
 	border-radius: 6px;
 	color: blue;
 }
@@ -56,8 +56,7 @@ input {
 
 #emoji-btn:active,
 #emoji-btn:hover {
-	/* box-shadow: inset 5px 5px 10px #bebebe, inset -5px -5px 10px #ffffff; */
-	outline: black 2px solid;
+	border: black 2px solid;
 }
 
 #emoji-input {
@@ -73,7 +72,8 @@ input {
 }
 
 #emoji-input:focus {
-	outline: black 2px solid;
+	border: black 2px solid;
+	outline: none;
 }
 
 #emoji-input::placeholder {
@@ -96,7 +96,6 @@ input {
 	background: #e0e0e0;
 	color: black;
 	border: none;
-	/* outline: black 1px solid; */
 	padding: 6px 20px;
 	border-radius: 6px;
 	margin: 0 8px;
@@ -109,12 +108,7 @@ input {
 }
 
 .btn:hover {
-	/* background: #eeeded; */
 	letter-spacing: 1px;
-	/* -webkit-box-shadow: 0px 5px 40px -10px rgb(100, 100, 100);
-	-moz-box-shadow: 0px 5px 40px -10px rgba(0, 0, 0, 0.57);
-	box-shadow: 5px 40px -10px rgba(0, 0, 0, 0.57); */
-	/* box-shadow: inset 10px 5px 30px #bebebe, inset -5px -5px -10px #ffffff; */
 	box-shadow: inset 3px 3px 10px #bebebe, inset -3px -3px 10px #ffffff;
 }
 


### PR DESCRIPTION
To provide radius support in Safari and Chrome, as the outline property was previously rendered with no radius.
Note: Chrome is still not displaying thin text on input and buttons.